### PR TITLE
docs(governance): wire CODEOWNERS and PR templates to docs governance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/compliance.md
+++ b/.github/PULL_REQUEST_TEMPLATE/compliance.md
@@ -1,0 +1,23 @@
+## Summary
+Describe the compliance change and applicable regulations/policies.
+
+## Evidence packet (required)
+- [ ] Internal sources with 1-line summaries:
+  - [ ] ... (policy/ADR/architecture)
+  - [ ] ... (monitoring/config)
+
+## Reviews
+- [ ] Domain owners requested
+- [ ] Security/Privacy & Child-safety/A11y reviewers requested
+
+## Checks
+- [ ] Link-check / markdownlint / Vale pass
+- [ ] Drift check vs sources completed
+- [ ] < 300 LOC, single-topic PR
+
+## Links
+- Governance (GitHub): [.github/instructions-github.md](../../.github/instructions-github.md)
+- Agent instructions: [docs/instructions.md](../../docs/instructions.md)
+- Agent policy (JSON): [docs/instructions.json](../../docs/instructions.json)
+
+Closes #12

--- a/.github/PULL_REQUEST_TEMPLATE/documentation.md
+++ b/.github/PULL_REQUEST_TEMPLATE/documentation.md
@@ -1,0 +1,24 @@
+## Summary
+Explain the documentation change and affected audience.
+
+## Evidence packet (required)
+- [ ] Links to internal sources with 1-line summaries:
+  - [ ] ... (ADR/OpenAPI/policy/arch/spec)
+  - [ ] ...
+
+## Reviews
+- [ ] Domain owners requested
+- [ ] Child-safety & A11y reviewers requested (if relevant)
+
+## Checks
+- [ ] markdownlint / link-check / Vale pass
+- [ ] Consistent with latest ADR/OpenAPI/policies
+- [ ] < 300 LOC, single-topic PR
+
+## Links
+- Governance (GitHub): [.github/instructions-github.md](../../.github/instructions-github.md)
+- Agent instructions: [docs/instructions.md](../../docs/instructions.md)
+- Agent policy (JSON): [docs/instructions.json](../../docs/instructions.json)
+- Agent charter: [docs/_agents/charter.md](../../docs/_agents/charter.md)
+
+Closes #12

--- a/.github/PULL_REQUEST_TEMPLATE/feature.md
+++ b/.github/PULL_REQUEST_TEMPLATE/feature.md
@@ -1,0 +1,23 @@
+## Summary
+Describe the feature and scope of changes.
+
+## Documentation & Evidence
+- [ ] Documentation updated or planned
+- [ ] Evidence packet attached (links + 1-line summaries)
+  - [ ] ... (ADR/OpenAPI/policy/arch/spec)
+
+## Reviews
+- [ ] Domain owners requested
+- [ ] Child-safety & A11y reviewers requested (if relevant)
+
+## Checks
+- [ ] Tests updated/added
+- [ ] Lint/CI pass; < 300 LOC, single-topic PR
+- [ ] Backward compatibility or version note
+
+## Links
+- Governance (GitHub): [.github/instructions-github.md](../../.github/instructions-github.md)
+- Agent instructions: [docs/instructions.md](../../docs/instructions.md)
+- Agent policy (JSON): [docs/instructions.json](../../docs/instructions.json)
+
+Refs #12

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,8 @@
+# CODEOWNERS for docs governance files
+# TODO: Replace @wahyumumtazsyah04 with org teams (e.g., @docs-core, @security-leads) when available
+# Tracking: https://github.com/wahyumumtazsyah04/MerajutASA/issues/12
+
+/.github/instructions-github.md  @wahyumumtazsyah04
+/docs/instructions.md            @wahyumumtazsyah04
+/docs/instructions.json          @wahyumumtazsyah04
+/docs/_agents/**                 @wahyumumtazsyah04


### PR DESCRIPTION
Scope
- Add CODEOWNERS entries for docs governance files
- Update PR templates (documentation, feature, compliance) to require evidence packets and link to governance

Why
- Enforce grounded-only documentation with child-safety/a11y guardrails
- Make governance discoverable at PR time

Changes
- CODEOWNERS for:
  - /.github/instructions-github.md
  - /docs/instructions.md
  - /docs/instructions.json
  - /docs/_agents/**
- PR templates updated with:
  - Evidence packet checklist
  - Child-safety & A11y reviewer prompts
  - Links to governance docs

Evidence packet
- .github/instructions-github.md — GitHub Instructions
- docs/instructions.md — Authoritative Agent Instructions
- docs/instructions.json — Machine policy; allowlist includes .github/instructions-github.md
- docs/_agents/charter.md — Agent Charter

Impact
- No code behavior changes
- Documentation workflow improvement; helps pass quality gates

Acceptance criteria
- CODEOWNERS maps files to owners
- PR templates show new checkboxes and links
- Link-check/markdownlint pass
- < 300 LOC, single-topic

Closes #12