### PR TITLE
docs(media): add CODEOWNERS for media docs and dashboards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS
+# Media stakeholder documentation and assets
+/docs/stakeholders/media/* @docs-core @security-leads
+/docs/stakeholders/media/media-assets/** @docs-core @security-leads
+/monitoring/dashboards/stakeholder/media/** @docs-core @security-leads


### PR DESCRIPTION
Scope: Add CODEOWNERS entries to route reviews for media stakeholder docs and dashboards.

Changes
- .github/CODEOWNERS: add patterns for:
  - docs/stakeholders/media/*
  - docs/stakeholders/media/media-assets/**
  - monitoring/dashboards/stakeholder/media/**

Labels: type:docs, area:stakeholders, stakeholder:media, priority:P1

Reviewers
- CODEOWNERS:domain
- CODEOWNERS:child-safety-a11y

Evidence Packet
- docs/stakeholders/media/README.md — references media assets and guidelines
- docs/instructions.md — requires reviewers incl. child-safety/a11y
- .github/copilot-instructions.md — grounding and review principles

Notes
- No content changes to docs; routing-only. <300 LOC.

Fixes: #8