### PR TITLE
docs(media): seed media metrics catalog and expand dashboard stub

### DIFF
--- a/monitoring/analytics/metrics/media.yaml
+++ b/monitoring/analytics/metrics/media.yaml
@@ -1,0 +1,18 @@
+version: 1
+owner: media-analytics
+metrics:
+  - key: media.impressions
+    name: Media Impressions
+    description: Count of article/post impressions linking to MerajutASA. No PII.
+    source: monitoring/dashboards/stakeholder/media/media-engagement-dashboard.md
+    pii: false
+  - key: media.referrals
+    name: Referral Sessions
+    description: Sessions originating from media outlets. Aggregated only.
+    source: monitoring/dashboards/stakeholder/media/media-engagement-dashboard.md
+    pii: false
+  - key: media.mentions
+    name: Verified Media Mentions
+    description: Count of verified mentions (manual curation).
+    source: docs/stakeholders/media/press-kit.md
+    pii: false

--- a/monitoring/dashboards/stakeholder/media/media-engagement-dashboard.md
+++ b/monitoring/dashboards/stakeholder/media/media-engagement-dashboard.md
@@ -1,3 +1,5 @@
-# Media Engagement Dashboard
+# Media Engagement Dashboard (Placeholder)
 
-This placeholder documents media engagement metrics. See docs/stakeholders/media/impact-metrics.md for definitions.
+- Sources: monitoring/analytics/metrics/media.yaml
+- Privacy: No PII; aggregated counts per docs/architecture/compliance/privacy-by-design.md
+- A11y: Use high-contrast palettes per docs/architecture/compliance/accessibility-compliance.md


### PR DESCRIPTION
Scope: Provide minimal metrics catalog and expand dashboard stub so media docs references resolve.

Changes
- monitoring/analytics/metrics/media.yaml — add 3 privacy-safe metrics
- monitoring/dashboards/stakeholder/media/media-engagement-dashboard.md — expand with sources/privacy/a11y

Labels: type:docs, area:operations, stakeholder:media, priority:P1

Reviewers: CODEOWNERS

Evidence Packet
- docs/stakeholders/media/impact-metrics.md — references metrics and dashboard
- docs/operations/monitoring/dashboard-setup.md — monitoring docs pointer
- docs/architecture/compliance/privacy-by-design.md — privacy baseline
- docs/architecture/compliance/accessibility-compliance.md — a11y baseline

Notes
- Pure docs/monitoring content; <300 LOC.