### PR TITLE
security(policies): add core Security Policy and Access Control docs (#45)

### DIFF
--- a/security/policies/access-control.md
+++ b/security/policies/access-control.md
@@ -1,0 +1,50 @@
+---
+title: "Access Control Policy"
+summary: "RBAC, least privilege, and review cadence for MerajutASA platform access."
+audience: ["security","administrators","maintainers","devops"]
+stakeholder: ["government","business","academia","community","media"]
+owner: "@security-leads"
+status: "in_review"
+version: "1.0.0"
+last_reviewed: "2025-08-08"
+tags: ["security","policy","access-control","rbac","child-safety"]
+---
+
+## Purpose
+Define consistent, auditable access control practices that minimize risk and protect children’s data.
+
+## Scope & Audience
+Applies to all identities (human and service), systems, environments, and datasets governed by MerajutASA.
+
+## Key Facts (Grounded)
+- Data sensitivity and handling: [security/policies/data-classification.md]
+- Acceptable Use boundaries: [security/policies/acceptable-use.md]
+- Security overview and incident process: [SECURITY.md]
+- Architecture control references: [docs/architecture/compliance/security-controls.md]
+- Ownership references: [.github/CODEOWNERS]
+
+## Policy Requirements
+1. Least Privilege: Grant the minimum permissions required to perform a task.
+2. Role-Based Access Control (RBAC): Define roles aligned to duties; map identities to roles, not raw privileges.
+3. Separation of Duties: No single identity should execute and approve high-risk changes end-to-end.
+4. Strong Authentication: MFA required for privileged roles and administrative consoles.
+5. Time-Bound Access: Use just-in-time elevation for exceptional tasks; auto-expire temporary grants.
+6. Periodic Reviews: Access reviews at least quarterly; remove dormant and unnecessary accounts.
+7. Service Accounts: Non-human identities scoped to specific resources; rotate credentials regularly; no shared accounts.
+8. Auditability: All access changes traceable via issues/PRs/tickets with reviewer sign-off.
+
+## Implementation Notes (Grounded)
+- Map datasets to classifications in [security/policies/data-classification.md] and restrict access accordingly.
+- Use ownership and review routing from [.github/CODEOWNERS] for sensitive areas.
+- Document exceptions in PRs with mitigation and review dates.
+
+## Accessibility & Child Safety
+- Access requests must avoid sharing child PII in free-text; use IDs from safe environments only.
+- Provide accessible request workflows and clear guidance for assistive technologies.
+
+## Validation & Monitoring (optional)
+- Periodic reconciliations of actual vs. intended access.
+- Link with incident response in [SECURITY.md] for escalation pathways.
+
+## Changelog
+- 1.0.0 (2025-08-08): Initial access control policy grounded to internal sources.

--- a/security/policies/security-policy.md
+++ b/security/policies/security-policy.md
@@ -1,0 +1,54 @@
+---
+title: "Security Policy (Core)"
+summary: "Platform-wide security posture with child-safety first, grounded in existing policies and controls."
+audience: ["security","maintainers","administrators","product","legal"]
+stakeholder: ["government","business","academia","community","media"]
+owner: "@security-leads"
+status: "in_review"
+version: "1.0.0"
+last_reviewed: "2025-08-08"
+tags: ["security","policy","child-safety","compliance"]
+---
+
+## Purpose
+Establish the core security policy for MerajutASA. Protect children and stakeholders by defining mandatory controls, links to detailed policies, and verification paths.
+
+## Scope & Audience
+- Applies to all platform components, data, users, and environments.
+- For security, maintainers, administrators, and reviewers across the penta-helix.
+
+## Key Facts (Grounded)
+- Root security overview: [SECURITY.md]
+- Data sensitivity levels: [security/policies/data-classification.md]
+- Communication channels & escalation: [security/policies/communication-security.md]
+- Acceptable use requirements: [security/policies/acceptable-use.md]
+- Control catalog (architecture): [docs/architecture/compliance/security-controls.md]
+- Compliance overview: [COMPLIANCE_MATRIX.md]
+
+## Policy Statements
+1. Child Safety First: Security decisions prioritize protection of children over convenience or speed.
+2. Least Privilege: Access is restricted to the minimum necessary (see Access Control policy below).
+3. Defense in Depth: Multiple complementary controls protect data and services.
+4. Secure-by-Default: New features must enable secure defaults and document risks.
+5. Incident Readiness: Detected issues are triaged and escalated per SECURITY.md with auditability.
+6. Grounded Documentation: All security guidance must cite internal sources and avoid unverifiable claims.
+
+## Controls (See Also “Security Controls” in Architecture)
+- Identity and Access: MFA for privileged roles; RBAC enforced; periodic access reviews.
+- Data Protection: Encryption in transit and at rest for sensitive data; classification-driven handling.
+- Change Management: Small, reversible changes; peer review; automated checks.
+- Monitoring: Security-relevant logs retained and reviewed; alerts linked to on-call.
+- Vendor/Integration: Contracts require minimum controls; credentials handled securely; secrets not committed.
+
+## Accessibility & Child Safety
+- Follow WCAG 2.1 AA for user-facing security UX.
+- Never include PII of children in examples or test data; use anonymized data.
+- Provide accessible reporting channels for security and child-safety concerns.
+
+## Validation & Monitoring (optional)
+- Link checks and policy linting in CI.
+- Periodic reviews against [COMPLIANCE_MATRIX.md].
+- Dashboard references provided in relevant monitoring docs (outside this file’s scope).
+
+## Changelog
+- 1.0.0 (2025-08-08): Initial core policy, grounded to existing internal documents.


### PR DESCRIPTION
Adds two missing security policy docs referenced by instructions safe-completion:
- security/policies/security-policy.md
- security/policies/access-control.md

Scope
- Two new files; grounded references only; consistent with existing policy tone.

Evidence Packet
- SECURITY.md — security overview and escalation
- security/policies/{communication-security.md, acceptable-use.md, data-classification.md}
- docs/architecture/compliance/security-controls.md — control catalog
- docs/instructions.json.safe_completion.on_refusal.link_policy_paths — requires these paths

Quality Gates
- Relative links only
- <300 LOC
- Single-topic PR (security policies)

Reviewers
- CODEOWNERS: security-leads, child-safety/a11y
