### PR TITLE
ops(docs): add maintenance hub README

### DIFF
--- a/docs/operations/maintenance/README.md
+++ b/docs/operations/maintenance/README.md
@@ -1,0 +1,12 @@
+# Operations: Maintenance
+
+This index groups operational maintenance topics. For architecture background, see docs/architecture/infrastructure/disaster-recovery.md and security-infrastructure.md.
+
+Topics to maintain and extend:
+- Backup procedures
+- Disaster recovery
+- Security updates
+- Performance tuning
+- Health checks
+
+See also: docs/MAINTENANCE.md for cadence and responsibilities.


### PR DESCRIPTION
Adds docs/operations/maintenance/README.md as the operations maintenance hub.

Evidence (in-repo):
- docs/operations/README.md
- docs/architecture/README.md
- .github/copilot-instructions.md