### PR TITLE
ops(docs): add incident response hub README

### DIFF
--- a/docs/operations/incident-response/README.md
+++ b/docs/operations/incident-response/README.md
@@ -1,0 +1,11 @@
+# Operations: Incident Response
+
+Operational runbook hub for incident management. For security architecture policy, see docs/architecture/security/incident-response.md.
+
+Included procedures (to be expanded in separate PRs):
+- Incident response plan
+- Escalation procedures
+- Communication protocols
+- Post-incident review
+
+Related: docs/operations/monitoring/ and SECURITY.md


### PR DESCRIPTION
Adds docs/operations/incident-response/README.md as the operations IR hub linking to security architecture IR policy and monitoring.
Evidence: docs/architecture/security/incident-response.md, docs/operations/monitoring/README.md, SECURITY.md