### PR TITLE
docs: add user-guides hub README

### DIFF
--- a/docs/user-guides/README.md
+++ b/docs/user-guides/README.md
@@ -1,0 +1,11 @@
+# User Guides
+
+This hub links end‑user guides by role. Content should follow docs/STYLE_GUIDE.md and be reviewed per docs/REVIEW_PROCESS.md.
+
+Roles (to be added under this directory in future PRs):
+- Orphanage administrators
+- Volunteers
+- Donors
+- Children (age‑appropriate)
+
+Reference: docs/stakeholders/community/getting-started/*.md for initial role content.


### PR DESCRIPTION
Adds docs/user-guides/README.md as the hub for role-based user guides, aligned with style and review processes.
Evidence: docs/STYLE_GUIDE.md, docs/REVIEW_PROCESS.md, docs/stakeholders/community/getting-started/